### PR TITLE
Add airport can instruct plane to land feature

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --require spec_helper
--- color
+--color
 --format documentation

--- a/lib/airport.rb
+++ b/lib/airport.rb
@@ -1,0 +1,8 @@
+class Airport
+  def initialize
+    @stands = []
+  end
+  def instruct_landing(plane)
+    @stands << plane 
+  end
+end

--- a/lib/plane.rb
+++ b/lib/plane.rb
@@ -1,0 +1,2 @@
+class Plane
+end

--- a/spec/airport_spec.rb
+++ b/spec/airport_spec.rb
@@ -1,0 +1,15 @@
+require 'airport'
+
+describe Airport do
+  subject(:airport) { described_class.new }
+  let(:plane_double) { double :plane }
+  describe '#instruct_landing' do
+    it 'can instruct a plane to land' do
+      expect(airport).to respond_to(:instruct_landing).with(1).argument 
+    end
+
+    it 'lands the plane at the airport' do
+      expect(airport.instruct_landing(plane_double)).to eq [plane_double]
+    end
+  end
+end

--- a/spec/plane_spec.rb
+++ b/spec/plane_spec.rb
@@ -1,0 +1,4 @@
+require 'plane'
+
+describe Plane do
+end


### PR DESCRIPTION
Creates airport and plane classes to allow airport to instruct a
plane to land, and for the plane to land

Adds method to airport class to instruct the plane to land and an
array to represent stands at the airport to track landed planes